### PR TITLE
add plugin and info for testing

### DIFF
--- a/plugins/plugin_object_ds_utk.inc
+++ b/plugins/plugin_object_ds_utk.inc
@@ -41,7 +41,7 @@ function islandora_bagit_plugin_object_ds_utk_init($islandora_object, $tmp_ds_di
       );
     }
   }
-
+ //
   if (count($files_to_add)) {
     return $files_to_add;
   }

--- a/plugins/plugin_object_ds_utk.inc
+++ b/plugins/plugin_object_ds_utk.inc
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Plugin for the Islandora BagIt Drupal module.
+ *
+ * Registers all the datastreams in an Islandora object so they are
+ * copied into the 'data' directory.
+ */
+
+/**
+ * Returns an array of source and destination file paths.
+ *
+ * @param object $islandora_object
+ *   The Islandora object to create a Bag for.
+ *
+ * @param string $tmp_ds_directory
+ *   The temporary directory where the datastream files have been downloaded.
+ *
+ * @return array|bool
+ *   An array of source and destination file paths, or FALSE
+ *   if no datastream files are present.
+ */
+function islandora_bagit_plugin_object_ds_utk_init($islandora_object, $tmp_ds_directory) {
+  $files_to_add = array();
+  $ds_files = islandora_bagit_retrieve_datastreams($islandora_object, $tmp_ds_directory);
+  // Add file source and dest paths for each datastream to the $files_to_add
+  // array. $files_to_add['dest'] must be relative to the Bag's data
+  // subdirectory.
+  foreach ($ds_files as $ds_filename) {
+    // Add each file in the directory to $files_to_add.
+    $source_file_to_add = $ds_filename;
+    $keepers = array('OBJ','MODS','RELS-EXT','RELS-INT','TECHMD','HOCR','OCR','POLICY','FULL-TEXT','COLLECTION_POLICY','Project.zip','TEI','EAD');
+    $info = pathinfo($source_file_to_add);
+    if ((file_exists($source_file_to_add) && is_file($source_file_to_add)) && in_array(basename($source_file_to_add, '.'.$info['extension']), $keepers) ) {
+      $files_to_add[] = array(
+        'source' => $source_file_to_add,
+        // We use basename here since there are no subdirectories in the Bag's
+        // 'data' directory.
+        'dest' => basename($ds_filename),
+      );
+    }
+  }
+
+  if (count($files_to_add)) {
+    return $files_to_add;
+  }
+  else {
+    return FALSE;
+  }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lib.utk.edu/browse/DIT-45?jql=text%20%7E%20%22bagit%22


# What does this Pull Request do?

Modify the bagit module to output only specified datastreams into a bag. And allow the bagging of a collection only object.

# What's new?

Allows the bagging of a collection only object.


# How should this be tested?

* in the GUI:  the screen should say the datastreams that are saved.
* use the /tmp default location
* for drush, the file can be unziped and checked.


# Additional Notes:
This goes into a new folder you'll need to create. 

```terminal
cd /var/www/drupal/sites/all/modules
mkdir custom
cd custom
git clone https://github.com/pc37utn/islandora_bagit.git
```
### GUI Settings:
Checked: Delete unserialized (zipped) Bags.
Checked: Provide link to download the Bag

Collection batch type: one Bag per object
Checked: Serialize collection Bags.
Checked: Display messages
Checked: Log the creation of Bags

Compression type: tgz

Object plugins
Checked: plugin_object_ds_utk
Checked: plugin_object_foxml
Checked: plugin_object_premis

Collection plugins: plugin_collection_basic

# Interested parties
